### PR TITLE
Add support for ENV vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The following table lists the configurable parameters of the ALTCHA Sentinel cha
 | `persistence.size` | PVC size | `10Gi` |
 | `persistence.storageClass` | PVC storage class | `""` (uses default) |
 | `persistence.mountPath` | Mount path for volume | `/data` |
+| `env` | Direct environment variables | `[]` |
+| `envFrom` | Load environment from ConfigMaps/Secrets | `[]` |
+| `extraEnvVars` | Extra environment variables with complex definitions | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
@@ -52,6 +55,89 @@ helm install altcha-sentinel \
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example:
+
+```bash
+helm install altcha-sentinel -f values.yaml altcha-org/sentinel
+```
+
+## Environment Variables
+
+The chart supports three ways to configure environment variables:
+
+### Direct Environment Variables
+
+Use the `env` parameter to set simple environment variables:
+
+```yaml
+env:
+  - name: LOG_LEVEL
+    value: "debug"
+  - name: SMTP_URL
+    value: "your-smtp-url"
+```
+
+### Environment Variables from ConfigMaps or Secrets
+
+Use the `envFrom` parameter to load entire ConfigMaps or Secrets as environment variables:
+
+```yaml
+envFrom:
+  - configMapRef:
+      name: my-app-config
+  - secretRef:
+      name: my-app-secrets
+```
+
+### Complex Environment Variables
+
+Use the `extraEnvVars` parameter for environment variables that reference specific keys from ConfigMaps or Secrets:
+
+```yaml
+extraEnvVars:
+  - name: REDIS_URL
+    valueFrom:
+      secretKeyRef:
+        name: redis-secret
+        key: connection-string
+  - name: CONFIG_VALUE
+    valueFrom:
+      configMapKeyRef:
+        name: app-config
+        key: config-value
+```
+
+### Complete Example
+
+Here's a complete example using all three methods:
+
+```yaml
+# values.yaml
+env:
+  - name: LOG_LEVEL
+    value: "info"
+  - name: PASSWORD_LOGIN_ENABLED
+    value: "0"
+
+envFrom:
+  - configMapRef:
+      name: sentinel-config
+  - secretRef:
+      name: sentinel-secrets
+
+extraEnvVars:
+  - name: SMTP_URL
+    valueFrom:
+      secretKeyRef:
+        name: credentials
+        key: smtp-url
+  - name: BASE_URL
+    valueFrom:
+      configMapKeyRef:
+        name: feature-config
+        key: base-url
+```
+
+Then install with:
 
 ```bash
 helm install altcha-sentinel -f values.yaml altcha-org/sentinel

--- a/charts/sentinel/Chart.yaml
+++ b/charts/sentinel/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: sentinel
 description: A Helm chart for ALTCHA Sentinel
-version: 0.8.1
+version: 0.8.2
 appVersion: "1.8.2"

--- a/charts/sentinel/templates/NOTES.txt
+++ b/charts/sentinel/templates/NOTES.txt
@@ -20,3 +20,16 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+{{- if or .Values.env .Values.envFrom .Values.extraEnvVars }}
+
+2. Environment variables have been configured:
+{{- if .Values.env }}
+   - Direct environment variables: {{ len .Values.env }} configured
+{{- end }}
+{{- if .Values.envFrom }}
+   - Environment from ConfigMaps/Secrets: {{ len .Values.envFrom }} sources configured
+{{- end }}
+{{- if .Values.extraEnvVars }}
+   - Complex environment variables: {{ len .Values.extraEnvVars }} configured
+{{- end }}
+{{- end }}

--- a/charts/sentinel/templates/deployment.yaml
+++ b/charts/sentinel/templates/deployment.yaml
@@ -44,6 +44,19 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+          {{- if or .Values.env .Values.extraEnvVars }}
+          env:
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/sentinel/values.yaml
+++ b/charts/sentinel/values.yaml
@@ -116,6 +116,39 @@ persistence:
   storageClassName: ""  # Set to your StorageClass or leave empty for default
   mountPath: /data  # Where to mount in the container
 
+# Environment variables to set in the container
+# Example:
+# env:
+#   - name: LOG_LEVEL
+#     value: "debug"
+#   - name: SMTP_URL
+#     value: "your-smtp-url"
+env: []
+
+# Environment variables from ConfigMaps or Secrets
+# Example:
+# envFrom:
+#   - configMapRef:
+#       name: my-app-config
+#   - secretRef:
+#       name: my-app-secrets
+envFrom: []
+
+# Extra environment variables with more complex definitions
+# Example:
+# extraEnvVars:
+#   - name: REDIS_URL
+#     valueFrom:
+#       secretKeyRef:
+#         name: redis-secret
+#         key: connection-string
+#   - name: CONFIG_VALUE
+#     valueFrom:
+#       configMapKeyRef:
+#         name: app-config
+#         key: config-value
+extraEnvVars: []
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This should be backwards compatible, but also allow configuration of ENV vars either directly in the Helm values, or via configmap/secret.