### PR TITLE
This PR introduces support for adding annotations to the Kubernetes Service resource through values.yaml.

### DIFF
--- a/charts/sentinel/templates/service.yaml
+++ b/charts/sentinel/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "sentinel.fullname" . }}
   labels:
     {{- include "sentinel.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/sentinel/values.yaml
+++ b/charts/sentinel/values.yaml
@@ -51,6 +51,12 @@ securityContext: {}
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
+  # Annotations to add to the Service.
+  # Example:
+  # annotations:
+  #   service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  #   service.beta.kubernetes.io/oci-load-balancer-shape: "flexible"
+  annotations: {}
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: LoadBalancer
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports


### PR DESCRIPTION
PR Description
Added a new annotations field under .Values.service.
Updated values.yaml with documentation and example usage.
Modified templates/service.yaml to render annotations when defined.
Why
Many users need to customize their Service resources with cloud-provider-specific annotations (e.g., AWS, OCI, GCP). This change provides flexibility while keeping defaults minimal.